### PR TITLE
Link creatures in cryos to their containing item

### DIFF
--- a/SavegameToolkit/ArkSavegame.cs
+++ b/SavegameToolkit/ArkSavegame.cs
@@ -413,6 +413,7 @@ namespace SavegameToolkit
                     }
                     foreach (var ob in storedGameObjects)
                     {
+                        ob.Parent = cryo;
                         ob.LoadProperties(cryoArchive, new GameObject(), 0);
                     }
 


### PR DESCRIPTION
This allows looking up which inventory the cryo is in, and hence its location.