### PR TITLE
[UNTESTED] Fix integer overflow when reading late object properties in big files. Better V11 CustomItemDatas redirection support.

### DIFF
--- a/SavegameToolkit/ArkArchive.cs
+++ b/SavegameToolkit/ArkArchive.cs
@@ -39,6 +39,8 @@ namespace SavegameToolkit {
 
         private readonly byte[] smallByteBuffer = new byte[bufferSize];
 
+        public short SaveVersion { get; internal set; }
+
         /// <summary>
         /// Enable or disable the current nameTable
         /// </summary>
@@ -81,6 +83,7 @@ namespace SavegameToolkit {
             mbbReader = new BinaryReader(mbb);
             state = toClone.state;
             isSlice = true;
+            SaveVersion = toClone.SaveVersion;
         }
 
         public ArkArchive Clone() => new ArkArchive(this);

--- a/SavegameToolkit/ArkSavegame.cs
+++ b/SavegameToolkit/ArkSavegame.cs
@@ -121,6 +121,8 @@ namespace SavegameToolkit
         {
             SaveVersion = archive.ReadShort();
 
+            archive.SaveVersion = SaveVersion;
+
             if (SaveVersion < 5 || SaveVersion > 12)
             {
                 throw new NotSupportedException("Found unknown Version " + SaveVersion);

--- a/SavegameToolkit/ArkSavegame.cs
+++ b/SavegameToolkit/ArkSavegame.cs
@@ -458,30 +458,14 @@ namespace SavegameToolkit
             {
                 if (!(o.Properties.First(p => p.NameString == "CustomItemDatas") is PropertyArray customData)) continue;
 
-                var cryoDataOffset = 0;
-                if (customData.Value is ArkArrayUnknown dataByteArray)
-                {
-                    var dataBytes = dataByteArray.ToArray<byte>();
-
-                    if (dataBytes.Length > 0)
-                    {
-                        using (MemoryStream ms = new MemoryStream(dataBytes))
-                        {
-                            using (ArkArchive a = new ArkArchive(ms))
-                            {
-                                if (dataByteArray.Count >= 10) // only care about first 10 bytes, not sure sure what comes after that.
-                                {
-                                    var cryoUnknown1 = a.ReadShort();
-                                    var cryoUnknown2 = a.ReadInt();
-                                    cryoDataOffset = a.ReadInt();
-                                }
-                                else
-                                {
-                                    cryoDataOffset = 0;
-                                }
-                            }
-                        }
-                    }
+                long cryoDataOffset = 0;
+                if (
+                    archive.SaveVersion > 10
+                    && customData.Value is ArkArrayStruct redirectors
+                    && redirectors.All(x => x is StructCustomItemDataRef)
+                ) {
+                    // TODO: probably best to: in cryos, take first entry. in souls, take second.
+                    cryoDataOffset = ((StructCustomItemDataRef)redirectors[0]).Position;
                 }
 
                 var creatureDataOffset = cryoDataOffset + storedOffset;

--- a/SavegameToolkit/GameObject.cs
+++ b/SavegameToolkit/GameObject.cs
@@ -280,7 +280,7 @@ namespace SavegameToolkit {
         }
 
         public void LoadProperties(ArkArchive archive, GameObject next, int propertiesBlockOffset) {
-            int offset = propertiesBlockOffset + propertiesOffset;
+            long offset = propertiesBlockOffset + propertiesOffset;
             long nextOffset = propertiesBlockOffset + next?.propertiesOffset ?? archive.Limit;
 
             archive.Position = offset;

--- a/SavegameToolkit/Structs/StructCustomItemDataRef.cs
+++ b/SavegameToolkit/Structs/StructCustomItemDataRef.cs
@@ -1,0 +1,59 @@
+﻿using System;
+using Newtonsoft.Json;
+using Newtonsoft.Json.Linq;
+using SavegameToolkit.Arrays;
+using SavegameToolkit.Types;
+
+namespace SavegameToolkit.Structs {
+
+    [JsonObject(MemberSerialization.OptIn)]
+    public class StructCustomItemDataRef : StructBase {
+
+        [JsonProperty(Order = 0)]
+        public short Unknown0 { get; private set; }
+        [JsonProperty(Order = 1)]
+        public long Position { get; private set; }
+        [JsonProperty(Order = 2)]
+        public ObjectReference[] ObjectRefs { get; private set; }
+        [JsonProperty(Order = 3)]
+        public ObjectReference[] ClassRefs { get; private set; }
+
+        public override void Init(ArkArchive archive)
+        {
+            // The first unknown field may be two fields - perhaps format version and archive index
+            Unknown0 = archive.ReadShort();
+            Position = archive.ReadLong();
+            ObjectRefs = new ObjectReference[archive.ReadInt()];
+            for (int index = 0; index < ObjectRefs.Length; index++)
+            {
+                ObjectRefs[index] = new ObjectReference(archive, 8);
+            }
+            ClassRefs = new ObjectReference[archive.ReadInt()];
+            for (int index = 0; index < ClassRefs.Length; index++)
+            {
+                ClassRefs[index] = new ObjectReference(archive, 8);
+            }
+        }
+
+        public override void Init(JObject node)
+        {
+            throw new NotImplementedException("JSON import of StructCustomItemDataRef has not been implemented");
+        }
+
+        public override void WriteJson(JsonTextWriter generator, WritingOptions writingOptions)
+        {
+            throw new NotImplementedException("JSON export of StructCustomItemDataRef has not been implemented");
+        }
+
+        public override void WriteBinary(ArkArchive archive)
+        {
+            throw new NotImplementedException("Binary export of StructCustomItemDataRef has not been implemented");
+        }
+
+        public override int Size(NameSizeCalculator nameSizer)
+        {
+            return sizeof(short) + sizeof(long) + sizeof(int) * 2 + ObjectRefs.Length * 8 + ClassRefs.Length * 8;
+        }
+    }
+
+}


### PR DESCRIPTION
This should address a bad integer offset (or rather a property table over-read within wrong context) mentioned under #5.

Largely untested, nowadays I don't play ARK and don't have any save file collection nor the time needed to wait for these files to load and import into ASB.

- The first commit fixes an overflow that occurs when calculating the absolute property table offset of later objects in big save files.
- The second two commits attempt to solve CustomItemDatas (later "CID" for short) reading.
- - I've drawn a few far-fetched conclusions on WC's implementation that seem **very** likely to me - therefore I've redone how we handle CID after #5 to ensure we don't reinterpret raw array contents outside of the property table read.
- - Ian reported seeing variable sizes of the "redirectors" - turns out the relocated data isn't sufficient to reconstruct an FCustomItemData struct we've seen in V9 as class and object references are missing. It appears those references are still written to the primary archive (the array). This should be now handled.