### PR TITLE
Re-worked cryo read to prevent multi-threading issues loading GameObject and Properties.

### DIFF
--- a/SavegameToolkit/Types/StoredItemOffset.cs
+++ b/SavegameToolkit/Types/StoredItemOffset.cs
@@ -1,0 +1,12 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Text;
+
+namespace SavegameToolkit.Types
+{
+    internal class StoredItemOffset
+    {
+        public GameObject ParentObject { get; internal set; }
+        public long ObjectOffset { get; internal set; }
+    }
+}


### PR DESCRIPTION
Re-worked read of cryo/trap references to read all data in forward-only before re-parenting and adding to Objects in a parallel loop.

GameObject constructor and LoadProperties methods both still use name tables internally which need to be read in single threaded to prevent mis-reads and possible duplication.

Added defensive check to ensure redictors array contains the index we're trying to read.  Had one that only had a "Settings" redirector for a Soul Trap and no "Dino" redirector.