### PR TITLE
Read ArkTribe and ArkProfile data (--UseStore)

### DIFF
--- a/SavegameToolkit/ArkStoreProfile.cs
+++ b/SavegameToolkit/ArkStoreProfile.cs
@@ -1,0 +1,119 @@
+﻿using Newtonsoft.Json;
+using Newtonsoft.Json.Linq;
+using SavegameToolkit.Propertys;
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace SavegameToolkit
+{
+    internal class ArkStoreProfile : GameObjectContainerMixin, IConversionSupport, IPropertyContainer
+    {
+
+        public int ProfileVersion { get; set; }
+
+        public List<IProperty> Properties => profile.Properties;
+
+        private GameObject profile;
+        private long propertiesBlockOffset;
+
+        public GameObject Profile
+        {
+            get => profile;
+            set
+            {
+                if (profile != null)
+                {
+                    int oldIndex = Objects.IndexOf(profile);
+                    if (oldIndex > -1)
+                    {
+                        Objects.RemoveAt(oldIndex);
+                    }
+                }
+
+                profile = value;
+                if (value != null && Objects.IndexOf(value) == -1)
+                {
+                    Objects.Insert(0, value);
+                }
+            }
+        }
+
+        public void ReadBinary(ArkArchive archive, ReadingOptions options)
+        {
+
+            propertiesBlockOffset = archive.Position;
+            var useNameTable = archive.UseNameTable;
+            archive.UseNameTable = false;
+            try
+            {
+                ProfileVersion = archive.ReadInt();
+
+                if (ProfileVersion != 1)
+                {
+                    //throw new NotSupportedException("Unknown Profile Version " + ProfileVersion);
+                }
+
+                int profilesCount = archive.ReadInt();
+
+                Objects.Clear();
+                ObjectMap.Clear();
+                for (int i = 0; i < profilesCount; i++)
+                {
+                    addObject(new GameObject(archive), options.BuildComponentTree);
+                }
+
+                for (int i = 0; i < profilesCount; i++)
+                {
+                    GameObject gameObject = Objects[i];
+                    if (gameObject.ClassString == "PrimalPlayerData" || gameObject.ClassString == "PrimalPlayerDataBP_C")
+                    {
+                        profile = gameObject;
+                    }
+
+                    gameObject.LoadProperties(archive, new GameObject(), propertiesBlockOffset);
+                }
+            }
+            catch
+            {
+
+            }
+            archive.UseNameTable = useNameTable;
+            //var tekGrams = Objects.Where(o => o.ClassString.ToLower().Contains("canteen")).ToList();
+
+        }
+
+
+        public int CalculateSize()
+        {
+            int size = sizeof(int) * 2;
+
+            NameSizeCalculator nameSizer = ArkArchive.GetNameSizer(false);
+
+            size += Objects.Sum(o => o.Size(nameSizer));
+
+            propertiesBlockOffset = size;
+
+            size += Objects.Sum(o => o.PropertiesSize(nameSizer));
+            return size;
+        }
+
+        public void WriteBinary(ArkArchive archive, WritingOptions options)
+        {
+            throw new NotImplementedException();
+        }
+
+        public void ReadJson(JToken node, ReadingOptions options)
+        {
+            throw new NotImplementedException();
+        }
+
+        public void WriteJson(JsonTextWriter generator, WritingOptions options)
+        {
+            throw new NotImplementedException();
+        }
+    }
+
+}

--- a/SavegameToolkit/ArkStoreTribe.cs
+++ b/SavegameToolkit/ArkStoreTribe.cs
@@ -1,0 +1,82 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using Newtonsoft.Json;
+using Newtonsoft.Json.Linq;
+using SavegameToolkit.Propertys;
+
+namespace SavegameToolkit
+{
+
+    public class ArkStoreTribe : GameObjectContainerMixin, IConversionSupport, IPropertyContainer
+    {
+
+        public int TribeVersion { get; set; }
+
+        public GameObject Tribe { get; set; }
+
+        public List<IProperty> Properties => Tribe.Properties;
+
+        private long propertiesBlockOffset;
+
+        public void ReadBinary(ArkArchive archive, ReadingOptions options)
+        {
+
+            propertiesBlockOffset = archive.Position;
+            var useNameTable = archive.UseNameTable;
+            archive.UseNameTable = false;
+
+            TribeVersion = archive.ReadInt();
+
+            if (TribeVersion != 1)
+            {
+                throw new NotSupportedException("Unknown Tribe Version " + TribeVersion);
+            }
+
+            int tribesCount = archive.ReadInt();
+
+            Objects.Clear();
+            ObjectMap.Clear();
+            for (int i = 0; i < tribesCount; i++)
+            {
+                var newObject = new GameObject(archive);
+
+                addObject(newObject, false);
+            }
+
+            for (int i = 0; i < tribesCount; i++)
+            {
+                GameObject gameObject = Objects[i];
+                if (gameObject.ClassString == "PrimalTribeData")
+                {
+                    Tribe = gameObject;
+                }
+
+                gameObject.LoadProperties(archive, new GameObject(), propertiesBlockOffset);
+            }
+
+            archive.UseNameTable = useNameTable;
+        }
+
+        public void WriteBinary(ArkArchive archive, WritingOptions options)
+        {
+            throw new NotImplementedException();
+        }
+
+        public int CalculateSize()
+        {
+            throw new NotImplementedException();
+        }
+
+        public void ReadJson(JToken node, ReadingOptions options)
+        {
+            throw new NotImplementedException();
+        }
+
+        public void WriteJson(JsonTextWriter generator, WritingOptions options)
+        {
+            throw new NotImplementedException();
+        }
+    }
+
+}

--- a/SavegameToolkit/GameObject.cs
+++ b/SavegameToolkit/GameObject.cs
@@ -279,7 +279,7 @@ namespace SavegameToolkit {
             archive.HasUnknownData = true;
         }
 
-        public void LoadProperties(ArkArchive archive, GameObject next, int propertiesBlockOffset) {
+        public void LoadProperties(ArkArchive archive, GameObject next, long propertiesBlockOffset) {
             long offset = propertiesBlockOffset + propertiesOffset;
             long nextOffset = propertiesBlockOffset + next?.propertiesOffset ?? archive.Limit;
 

--- a/SavegameToolkit/ReadingOptions.cs
+++ b/SavegameToolkit/ReadingOptions.cs
@@ -65,6 +65,8 @@ namespace SavegameToolkit
         /// <code>true</code> if reading, <code>false</code> if skipping
         /// </summary>
         public bool CryopodCreatures { get; private set; } = true;
+        public bool StoredTribes { get; set; } = false;
+        public bool StoredProfiles { get; set; } = false;
 
         public bool BuildComponentTree { get; private set; }
 
@@ -170,6 +172,19 @@ namespace SavegameToolkit
             CryopodCreatures = cryopodCreatures;
             return this;
         }
+
+        public ReadingOptions WithStoredTribes(bool storedTribes)
+        {
+            StoredTribes = storedTribes;
+            return this;
+        }
+
+        public ReadingOptions WithStoredProfiles(bool storedProfiles)
+        {
+            StoredProfiles = storedProfiles;
+            return this;
+        }
+
 
         public ReadingOptions WithBuildComponentTree(bool buildComponentTree)
         {

--- a/SavegameToolkit/Types/ChunkedStore.cs
+++ b/SavegameToolkit/Types/ChunkedStore.cs
@@ -1,0 +1,90 @@
+﻿using Newtonsoft.Json.Linq;
+using Newtonsoft.Json;
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace SavegameToolkit.Types
+{
+    internal class ChunkedStore : IConversionSupport
+    {
+        internal struct ChunkInfo
+        {
+            public int ArchiveIndex { get; private set; }
+            public long ArchiveOffset { get; private set; }
+            public long Unknown { get; private set; }
+            public long Size { get; private set; }
+
+            internal static ChunkInfo ReadBinary(ArkArchive archive)
+            {
+                ChunkInfo result = new ChunkInfo();
+                result.ArchiveIndex = archive.ReadInt();
+                result.ArchiveOffset = archive.ReadLong();
+                result.Unknown = archive.ReadLong();
+                result.Size = archive.ReadLong();
+                return result;
+            }
+        }
+
+        public long TotalIndexSize { get; private set; }
+        public long TotalDataSize { get; private set; }
+        public List<ChunkInfo> IndexChunks { get; private set; }
+        public List<ChunkInfo> DataChunks { get; private set; }
+
+        public void ReadBinary(ArkArchive archive, ReadingOptions options)
+        {
+            bool versioned = archive.ReadInt() == -1;
+            int version = archive.ReadInt();
+            if (!versioned || version != 2)
+            {
+                throw new NotSupportedException("Only version 2 ChunkedStores can be read.");
+            }
+
+            (TotalDataSize, DataChunks) = _readChunkChain(archive, 1);
+            (TotalIndexSize, IndexChunks) = _readChunkChain(archive, 24);
+
+            // TODO: seems to be a map<ID, Object>.
+            // TODO: each index entry looks to be 64-bit ID + 64-bit offset (relative to data buffer start) + 64-bit
+            // TODO: sub-buffer size.
+            // TODO: handle the chunking, read the tribe/player data, and should be good.
+        }
+
+        private Tuple<long, List<ChunkInfo>> _readChunkChain(ArkArchive archive, int elementSize)
+        {
+            List<ChunkInfo> results = new List<ChunkInfo>();
+
+            long totalSize = archive.ReadLong() * elementSize;
+            long bytesRemaining = totalSize;
+            while (bytesRemaining > 0)
+            {
+                ChunkInfo chunk = ChunkInfo.ReadBinary(archive);
+                bytesRemaining -= chunk.Size;
+                results.Add(chunk);
+            }
+
+            return new Tuple<long, List<ChunkInfo>>(totalSize, results);
+        }
+
+        public void WriteBinary(ArkArchive archive, WritingOptions options)
+        {
+            throw new NotImplementedException();
+        }
+
+        public int CalculateSize()
+        {
+            throw new NotImplementedException();
+        }
+
+        public void ReadJson(JToken node, ReadingOptions options)
+        {
+            throw new NotImplementedException();
+        }
+
+        public void WriteJson(JsonTextWriter generator, WritingOptions options)
+        {
+            throw new NotImplementedException();
+        }
+    }
+}

--- a/SavegameToolkit/Types/StoredItemOffset.cs
+++ b/SavegameToolkit/Types/StoredItemOffset.cs
@@ -1,0 +1,12 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Text;
+
+namespace SavegameToolkit.Types
+{
+    internal class StoredItemOffset
+    {
+        public GameObject ParentObject { get; internal set; }
+        public long ObjectOffset { get; internal set; }
+    }
+}


### PR DESCRIPTION
Once again assisted by Alex this addition allows the read of .arktribe and .arkprofile file data that is now stored within the .ark save file itself when --usestore is enabled.